### PR TITLE
68 mock external api calls

### DIFF
--- a/Tests/test_geocode.py
+++ b/Tests/test_geocode.py
@@ -31,6 +31,7 @@ class geocodeTestCase(unittest.TestCase):
         assert cache_dir.is_dir()
         assert len([c for c in cache_dir.glob("*.p") if "gmaps" not in c.name]) == 0
 
+    @unittest.skip("Skipped to avoid external API calls")
     def test_force_setup(self):
         """Test the `force_setup()` method."""
         with Geocoder() as geo:

--- a/Tests/test_geocode.py
+++ b/Tests/test_geocode.py
@@ -12,7 +12,10 @@ Jamie Taylor & Ethan Jones 2020-05-22
 import sys
 import os
 import unittest
+from unittest.mock import MagicMock
+from shapely.geometry import Polygon
 from pathlib import Path
+import geopandas as gpd
 
 from numpy.testing import assert_almost_equal, assert_equal
 
@@ -39,6 +42,120 @@ class geocodeTestCase(unittest.TestCase):
         cache_dir = geo.cache_manager.cache_dir
         assert cache_dir.is_dir()
         assert len([c for c in cache_dir.glob("*.p") if "gmaps" not in c.name]) == 17
+
+    def test_force_setup_without_external_api_calls(self):
+        """Test the `force_setup()` method with mocked components."""
+        with Geocoder() as geo:
+
+            def mock_neso_force_setup():
+
+                gsp_boundaries = gpd.GeoDataFrame(
+                    {
+                        "GSPs": ["BRED_1", "DEWP"],
+                        "GSPGroup": ["_G", "_N"],
+                        "geometry": [
+                            Polygon(
+                                [
+                                    (-2.1, 53.3),
+                                    (-2.0, 53.3),
+                                    (-2.0, 53.4),
+                                    (-2.1, 53.4),
+                                    (-2.1, 53.3),
+                                ]
+                            ),
+                            Polygon(
+                                [
+                                    (-3.2, 55.9),
+                                    (-3.1, 55.9),
+                                    (-3.1, 56.0),
+                                    (-3.2, 56.0),
+                                    (-3.2, 55.9),
+                                ]
+                            ),
+                        ],
+                    },
+                    crs="EPSG:4326",
+                )
+                for version in ["20220314", "20250109", "20251204"]:
+                    geo.cache_manager.write(f"gsp_boundaries_{version}", gsp_boundaries)
+                geo.cache_manager.write("dno_boundaries", gpd.GeoDataFrame({}))
+
+            def mock_ons_nrs_force_setup():
+                llsoa_boundaries = gpd.GeoDataFrame(
+                    {
+                        "region_id": [
+                            "E01012082",
+                            "E01011214",
+                            "E01002050",
+                            "W01000323",
+                            "S01008087",
+                        ],
+                        "geometry": [
+                            Polygon(
+                                [
+                                    (-1.2, 54.5),
+                                    (-1.19, 54.5),
+                                    (-1.19, 54.55),
+                                    (-1.2, 54.55),
+                                    (-1.2, 54.5),
+                                ]
+                            ),
+                            Polygon(
+                                [
+                                    (-1.71, 53.66),
+                                    (-1.69, 53.66),
+                                    (-1.69, 53.67),
+                                    (-1.71, 53.67),
+                                    (-1.71, 53.66),
+                                ]
+                            ),
+                            Polygon(
+                                [
+                                    (-0.07, 51.57),
+                                    (-0.06, 51.57),
+                                    (-0.06, 51.58),
+                                    (-0.07, 51.58),
+                                    (-0.07, 51.57),
+                                ]
+                            ),
+                            Polygon(
+                                [
+                                    (-3.14, 53.20),
+                                    (-3.12, 53.20),
+                                    (-3.12, 53.21),
+                                    (-3.14, 53.21),
+                                    (-3.14, 53.20),
+                                ]
+                            ),
+                            Polygon(
+                                [
+                                    (-4.23, 55.91),
+                                    (-4.21, 55.91),
+                                    (-4.21, 55.93),
+                                    (-4.23, 55.93),
+                                    (-4.23, 55.91),
+                                ]
+                            ),
+                        ],
+                    },
+                    crs="EPSG:4326",
+                )
+                for version in ["2011", "2021"]:
+                    geo.cache_manager.write(
+                        f"llsoa_boundaries_{version}", llsoa_boundaries
+                    )
+                    geo.ons_nrs._load_datazone_lookup(version)
+                geo.ons_nrs._load_constituency_lookup()
+                geo.ons_nrs._load_lad_lookup()
+                geo.ons_nrs._load_llsoa_lookup()
+
+            geo.neso.force_setup = MagicMock(side_effect=mock_neso_force_setup)
+            geo.ons_nrs.force_setup = MagicMock(side_effect=mock_ons_nrs_force_setup)
+
+            geo.force_setup()
+
+            geo.neso.force_setup.assert_called_once()
+            geo.ons_nrs.force_setup.assert_called_once()
 
     def test_geocode_llsoa(self):
         """


### PR DESCRIPTION
Added a `test_force_setup_without_external_api_calls` unittest to test force setup with minimal external API calls. Time for running the tests down to <2 minutes from ~48 minutes