### PR TITLE
use 2021 version of LSOAs for reverse geocoding if no version is given

### DIFF
--- a/geocode/geocode.py
+++ b/geocode/geocode.py
@@ -298,7 +298,7 @@ class Geocoder:
             version = kwargs.pop("version", "20260209")
             return self.neso.reverse_geocode_gsp(latlons, version, **kwargs)
         elif entity == "llsoa":
-            version = kwargs.pop("version", "2011")
+            version = kwargs.pop("version", "2021")
             return self.ons_nrs.reverse_geocode_llsoa(
                 latlons, version=version, **kwargs
             )


### PR DESCRIPTION
Use the latest version of LSOAs for reverse geocoding when a version isn't specified by the user